### PR TITLE
Handle Arrays too for MPI_Allreduce subroutine

### DIFF
--- a/src/mpi.f90
+++ b/src/mpi.f90
@@ -58,6 +58,7 @@ module mpi
     interface MPI_Allreduce
         module procedure MPI_Allreduce_scalar
         module procedure MPI_Allreduce_1d
+        module procedure MPI_Allreduce_array
     end interface
 
     interface MPI_Wtime
@@ -265,6 +266,16 @@ module mpi
         integer, intent(out), optional :: ierror
         call c_mpi_allreduce_1d(sendbuf, recvbuf, count, datatype, op, comm, ierror)
     end subroutine
+
+    subroutine MPI_Allreduce_array(sendbuf, recvbuf, count, datatype, op, comm, ierror)
+        use mpi_c_bindings, only: c_mpi_allreduce_array
+        ! Declare both send and recv as arrays:
+        real(8), dimension(:), intent(in)  :: sendbuf
+        real(8), dimension(:), intent(out) :: recvbuf
+        integer, intent(in) :: count, datatype, op, comm
+        integer, intent(out), optional :: ierror
+        call c_mpi_allreduce_array(sendbuf, recvbuf, count, datatype, op, comm, ierror)
+    end subroutine MPI_Allreduce_array
 
     function MPI_Wtime_proc() result(time)
         use mpi_c_bindings, only: c_mpi_wtime

--- a/src/mpi.f90
+++ b/src/mpi.f90
@@ -10,7 +10,7 @@ module mpi
     integer, parameter :: MPI_SUCCESS = 0
 
     integer, parameter :: MPI_COMM_WORLD = 0
-    real(8), parameter :: MPI_IN_PLACE = 1
+    real(8), parameter :: MPI_IN_PLACE = -1
     integer, parameter :: MPI_SUM = 1
     integer, parameter :: MPI_INFO_NULL = 0
     integer :: MPI_STATUS_IGNORE = 0

--- a/src/mpi_c_bindings.f90
+++ b/src/mpi_c_bindings.f90
@@ -102,6 +102,14 @@ module mpi_c_bindings
             integer(c_int), intent(out), optional :: ierror
         end subroutine
 
+        subroutine c_mpi_allreduce_array(sendbuf, recvbuf, count, datatype, op, comm, ierror) bind(C, name="mpi_allreduce_wrapper")
+            use iso_c_binding, only: c_int, c_double
+            real(c_double), dimension(*), intent(in)  :: sendbuf
+            real(c_double), dimension(*), intent(out) :: recvbuf
+            integer(c_int), intent(in) :: count, datatype, op, comm
+            integer(c_int), intent(out), optional :: ierror
+        end subroutine c_mpi_allreduce_array
+
         function c_mpi_wtime() result(time) bind(C, name="mpi_wtime_wrapper")
             use iso_c_binding, only: c_double
             real(c_double) :: time

--- a/src/mpi_wrapper.c
+++ b/src/mpi_wrapper.c
@@ -193,7 +193,7 @@ void mpi_allreduce_wrapper(const double *sendbuf, double *recvbuf, int *count,
     2. the first argument (i.e. sendbuf) as "MPI_IN_PLACE" for now as it's always
        used as such in POT3D codebase
     */
-    *ierror = MPI_Allreduce(MPI_IN_PLACE, recvbuf, *count, datatype, MPI_SUM, comm);
+    *ierror = MPI_Allreduce(sendbuf, recvbuf, *count, datatype, MPI_SUM, comm);
 }
 
 double mpi_wtime_wrapper() {

--- a/src/mpi_wrapper.c
+++ b/src/mpi_wrapper.c
@@ -1,5 +1,6 @@
 #include <mpi.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #define MPI_STATUS_SIZE 5
 
@@ -193,7 +194,11 @@ void mpi_allreduce_wrapper(const double *sendbuf, double *recvbuf, int *count,
     2. the first argument (i.e. sendbuf) as "MPI_IN_PLACE" for now as it's always
        used as such in POT3D codebase
     */
-    *ierror = MPI_Allreduce(sendbuf, recvbuf, *count, datatype, MPI_SUM, comm);
+   if (*sendbuf == -1) {
+        *ierror = MPI_Allreduce(MPI_IN_PLACE , recvbuf, *count, datatype, MPI_SUM, comm);
+   } else {
+        *ierror = MPI_Allreduce(sendbuf , recvbuf, *count, datatype, MPI_SUM, comm);
+   }
 }
 
 double mpi_wtime_wrapper() {


### PR DESCRIPTION
current status on this PR

```clojure
 aditya-trivedi   src    all ≢  ?2 ~3 -1    mpicc -c mpi_wrapper.c -o mpi_wrapper.o
 aditya-trivedi   src    all ≢  ?2 ~3 -1    mpif90 -c mpi_c_bindings.f90 mpi.f90
 aditya-trivedi   src    all ≢  ?2 ~3 -1    mpif90 mpi_c_bindings.o mpi_wrapper.o mpi.o allreduce.f90 -o all && ./all
 Allreduce test completed with            0  errors.

 aditya-trivedi   src    all ≢  ?2 ~3 -1    conda activate lf
 aditya-trivedi   src    all ≢  ?2 ~3 -1    gcc -I$CONDA_PREFIX/include -c mpi_wrapper.c
 aditya-trivedi   src    all ≢  ?2 ~3 -1    gfortran -c mpi_c_bindings.f90 mpi.f90 
 aditya-trivedi   src    all ≢  ?2 ~3 -1    gfortran  -L$CONDA_PREFIX/lib -lmpi mpi_c_bindings.o mpi_wrapper.o mpi.o allreduce.f90 -o all && ./all
 Allreduce test completed with            0  errors.
```