### PR TITLE
Fix DataType of sendbuf and recvbuf

### DIFF
--- a/tests/allreduce.f90
+++ b/tests/allreduce.f90
@@ -13,7 +13,8 @@ program main
     use mpi
     external uop
     integer ierr, errs
-    integer count, vin(65000), vout(65000), i, size
+    real(8)  :: vin(65000),vout(65000)
+    integer :: i, count, size
     integer :: comm
 
     errs = 0
@@ -28,8 +29,7 @@ program main
             vin(i) = i
             vout(i) = -1
         enddo
-        call mpi_allreduce( vin, vout, count, MPI_INTEGER, MPI_SUM,  &
-    &                       comm, ierr )
+        call mpi_allreduce( vin, vout, count, MPI_REAL8, MPI_SUM, comm, ierr )
     !         Check that all results are correct
         do i=1, count
             if (vout(i) .ne. i * size) then

--- a/tests/allreduce.f90
+++ b/tests/allreduce.f90
@@ -1,4 +1,4 @@
-subroutine uop( cin, cout, count, datatype )
+subroutine uop( cin, cout, count)
     use mpi
     integer cin(*), cout(*)
     integer count

--- a/tests/allreduce.f90
+++ b/tests/allreduce.f90
@@ -1,17 +1,20 @@
-subroutine uop( cin, cout, count)
-    use mpi
-    integer cin(*), cout(*)
-    integer count
-    integer i
+module mod_uop
+    contains
+    subroutine uop( cin, cout, count)
+        use mpi
+        integer cin(*), cout(*)
+        integer count
+        integer i
 
-    do i=1, count
-        cout(i) = cin(i) + cout(i)
-    enddo
-end subroutine
+        do i=1, count
+            cout(i) = cin(i) + cout(i)
+        end do
+    end subroutine
+end module mod_uop
   
 program main
     use mpi
-    external uop
+    use mod_uop
     integer ierr, errs
     real(8)  :: vin(65000),vout(65000)
     integer :: i, count, size
@@ -24,24 +27,22 @@ program main
     comm = MPI_COMM_WORLD
     call mpi_comm_size( comm, size, ierr )
     count = 1
-    do while (count .lt. 65000)
+    do while (count < 65000)
         do i=1, count
             vin(i) = i
             vout(i) = -1
-        enddo
+        end do
         call mpi_allreduce( vin, vout, count, MPI_REAL8, MPI_SUM, comm, ierr )
     !         Check that all results are correct
         do i=1, count
-            if (vout(i) .ne. i * size) then
+            if (vout(i) /= i * size) then
                 errs = errs + 1
-                if (errs .lt. 10) print *, "vout(",i,") = ", vout(i)
-            endif
-        enddo
+                if (errs < 10) print *, "vout(",i,") = ", vout(i)
+            end if
+        end do
         count = count + count
-    enddo
+    end do
 
     print *, "Allreduce test completed with ", errs, " errors."
-
-
     call mpi_finalize(errs)
 end

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -14,7 +14,9 @@ $FC -c ../src/mpi.f90
 
 for file in *.f90; do
   filename=$(basename "$file" .f90)
-
+  if [ "$filename" == "allreduce" ] && ([ "$FC" == "lfortran" ] || [ "$FC" == "lfortran --fast" ]); then
+    FC='lfortran --implicit-interface'
+  fi
   $FC -c $file
   $FC mpi_wrapper.o mpi_c_bindings.o mpi.o $filename.o -o $filename -L$CONDA_PREFIX/lib -lmpi -Wl,-rpath,$CONDA_PREFIX/lib
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -14,9 +14,6 @@ $FC -c ../src/mpi.f90
 
 for file in *.f90; do
   filename=$(basename "$file" .f90)
-  if [ "$filename" == "allreduce" ] && ([ "$FC" == "lfortran" ] || [ "$FC" == "lfortran --fast" ]); then
-    FC='lfortran --implicit-interface'
-  fi
   $FC -c $file
   $FC mpi_wrapper.o mpi_c_bindings.o mpi.o $filename.o -o $filename -L$CONDA_PREFIX/lib -lmpi -Wl,-rpath,$CONDA_PREFIX/lib
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -14,11 +14,7 @@ $FC -c ../src/mpi.f90
 
 for file in *.f90; do
   filename=$(basename "$file" .f90)
-  # TODO: currently "allreduce.f90" fails to compile, hence
-  # we skip that test for now
-  if [ "$filename" == "allreduce" ]; then
-    continue
-  fi
+
   $FC -c $file
   $FC mpi_wrapper.o mpi_c_bindings.o mpi.o $filename.o -o $filename -L$CONDA_PREFIX/lib -lmpi -Wl,-rpath,$CONDA_PREFIX/lib
 


### PR DESCRIPTION
This is due to the fact that currently we only handle the real(8) arrays in MPI_AllReduce
Will make a PR to handle integer Array in a while and test it too (This PR is just to remove unwanted skip in the run_tests.sh script