### PR TITLE
refactor: move MPI_Finalize C wrapper to pure Fortran

### DIFF
--- a/src/mpi.f90
+++ b/src/mpi.f90
@@ -147,14 +147,15 @@ module mpi
         use mpi_c_bindings, only: c_mpi_finalize
         use iso_c_binding, only: c_int
         integer, optional, intent(out) :: ierr
-        integer :: local_ierr
+        integer(c_int) :: local_ierr
+
+        !> assigns the status code to integer of kind 'c_int'
+        local_ierr = c_mpi_finalize()
         if (present(ierr)) then
-            call c_mpi_finalize(ierr)
-        else
-            call c_mpi_finalize(local_ierr)
-            if (local_ierr /= 0) then
-                print *, "MPI_Finalize failed with error code: ", local_ierr
-            end if
+            !> we need to cast it to a Fortran integer, hence the use of 'int'
+            ierr = int(local_ierr)
+        else if (local_ierr /= 0) then
+            print *, "MPI_Finalize failed with error code: ", int(local_ierr)
         end if
     end subroutine
 

--- a/src/mpi_c_bindings.f90
+++ b/src/mpi_c_bindings.f90
@@ -14,10 +14,9 @@ module mpi_c_bindings
             integer(c_int), intent(out) :: ierr
         end subroutine c_mpi_init_thread
 
-        subroutine c_mpi_finalize(ierr) bind(C, name="mpi_finalize_wrapper")
+        integer(c_int) function c_mpi_finalize() bind(C, name="MPI_Finalize")
             use iso_c_binding, only : c_int
-            integer(c_int), intent(out) :: ierr
-        end subroutine c_mpi_finalize
+        end function c_mpi_finalize
 
         subroutine c_mpi_comm_size(comm, size, ierr) bind(C, name="mpi_comm_size_wrapper")
             use iso_c_binding, only: c_int

--- a/src/mpi_wrapper.c
+++ b/src/mpi_wrapper.c
@@ -18,10 +18,6 @@ void mpi_init_thread_wrapper(int *required, int *provided, int *ierr) {
     *ierr = MPI_Init_thread(&argc, &argv, thread_support, provided);
 }
 
-void mpi_finalize_wrapper(int *ierr) {
-    *ierr = MPI_Finalize();
-}
-
 void mpi_comm_size_wrapper(int *comm_f, int *size, int *ierr) {
     MPI_Comm comm = MPI_Comm_f2c(*comm_f);
     *ierr = MPI_Comm_size(comm, size);


### PR DESCRIPTION
Towards completing the issue: https://github.com/gxyd/c_mpi/issues/21