### PR TITLE
test: improve run_tests.sh script to be less verbose

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,4 +1,11 @@
-set -ex
+#!/bin/bash
+set -e
+
+# Color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
 
 MPIEXEC=${CONDA_PREFIX}/bin/mpiexec
 
@@ -8,20 +15,25 @@ else
   CC=clang
 fi
 
+# Compile C and Fortran sources
 $CC -I$CONDA_PREFIX/include -c ../src/mpi_wrapper.c
 $FC -c ../src/mpi_c_bindings.f90
 $FC -c ../src/mpi.f90
 
 for file in *.f90; do
   filename=$(basename "$file" .f90)
+  echo -e "${YELLOW}Compiling $filename...${NC}"
   $FC -c $file
   $FC mpi_wrapper.o mpi_c_bindings.o mpi.o $filename.o -o $filename -L$CONDA_PREFIX/lib -lmpi -Wl,-rpath,$CONDA_PREFIX/lib
 
-  echo "Running $filename with 1 MPI rank..."
-  ${MPIEXEC} -np 1 $filename
-  echo "Done!"
+  for np in 1 2; do
+    echo -e "${YELLOW}Running $filename with $np MPI ranks...${NC}"
+    if ${MPIEXEC} -np $np ./$filename; then
+      echo -e "${GREEN}Test $filename with $np MPI ranks PASSED!${NC}"
+    else
+      echo -e "${RED}Test $filename with $np MPI ranks FAILED!${NC}"
+      exit 1
+    fi
+  done
 
-  echo "Running $filename with 2 MPI rank..."
-  ${MPIEXEC} -np 2 $filename
-  echo "Done!"
 done


### PR DESCRIPTION
## Description

this makes it clear with colors, which test is starting, which failed and which test passed

The output now looks something like below on my terminal:

![Screenshot 2025-03-21 at 12 49 49 PM](https://github.com/user-attachments/assets/72c9f8a1-8e96-43ed-b1e1-5fc7d3078096)
