### PR TITLE
initialize in a separate line to avoid LFortran warning

### DIFF
--- a/src/mpi.f90
+++ b/src/mpi.f90
@@ -141,11 +141,11 @@ module mpi
         integer, intent(out) :: provided
         integer, optional, intent(out) :: ierr
         integer(c_int) :: local_ierr
-        integer(c_int) :: argc = 0
+        integer(c_int) :: argc
         type(c_ptr) :: argv = c_null_ptr
         integer(c_int) :: c_required
         integer(c_int) :: c_provided
-
+        argc = 0
         ! Map Fortran MPI_THREAD_FUNNELED to C MPI_THREAD_FUNNELED if needed
         c_required = int(required, c_int)
 


### PR DESCRIPTION
## Description

This removes a minor warning when running tests with LFortran, the warning is:
```console
warning: Assuming implicit save attribute for variable declaration
   --> ../src/mpi.f90:144:27
    |
144 |         integer(c_int) :: argc = 0
    |                           ^^^^^^^^ help: add explicit save attribute or parameter attribute or initialize in a separate statement


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
```

which doesn't occur anymore.