### PR TITLE
ENH: Add Functionality of running only one test file if specified

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -28,18 +28,39 @@ else
   CC=clang
 fi
 
-# compile C and Fortran sources
-$CC -I$CONDA_PREFIX/include -c ../src/mpi_wrapper.c
+# If user specified a particular test (e.g. ./run_tests.sh bcast.f90),
+# then only build & run that file. Otherwise, build & run all *.f90 files.
+
+if [ $# -gt 0 ]; then
+  TEST_FILES=("$@")
+  echo -e "${YELLOW}Received argument(s). Will only compile/run: ${TEST_FILES[*]}${NC}"
+else
+  # No arguments, so gather all .f90 test files in the current directory
+  TEST_FILES=( *.f90 )
+  echo -e "${YELLOW}No specific test file given. Will compile/run all .f90 tests...${NC}"
+fi
+
+# Compile the C and Fortran sources for the MPI wrappers
+$CC -I"$CONDA_PREFIX/include" -c ../src/mpi_wrapper.c
 $FC -c ../src/mpi_c_bindings.f90
 $FC -c ../src/mpi.f90
 
 start_time=$(date +%s)
-for file in *.f90; do
+
+# Now compile & run each requested test
+for file in "${TEST_FILES[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    echo -e "${RED}Test file '$file' not found! Skipping...${NC}"
+    continue
+  fi
+
   filename=$(basename "$file" .f90)
   echo -e "${YELLOW}Compiling $filename...${NC}"
-  $FC -c $file
-  $FC mpi_wrapper.o mpi_c_bindings.o mpi.o $filename.o -o $filename -L$CONDA_PREFIX/lib -lmpi -Wl,-rpath,$CONDA_PREFIX/lib
+  $FC -c "$file"
+  $FC mpi_wrapper.o mpi_c_bindings.o mpi.o "$filename.o" \
+     -o "$filename" -L"$CONDA_PREFIX/lib" -lmpi -Wl,-rpath,"$CONDA_PREFIX/lib"
 
+  # Test with 1, 2, and 4 ranks
   for np in 1 2 4; do
     # set MPIEXEC_ARGS based on MPI type and number of ranks
     # `--oversubscribe` isn't needed with Open MPI when running
@@ -63,6 +84,7 @@ done
 
 end_time=$(date +%s)
 elapsed_time=$((end_time - start_time))
+
 echo ""
 echo -e "${YELLOW}... Running standalone tests took ${elapsed_time} seconds ...${NC}"
 echo ""


### PR DESCRIPTION
With this enhancement we can do this 

```clojure
 aditya-trivedi   tests    script_enhance ≢    FC='gfortran' ./run_tests.sh bcast_1.f90 
Received argument(s). Will only compile/run: bcast_1.f90
Compiling bcast_1...
Running bcast_1 with 1 MPI ranks...
 Rank=           0  received integer=           1
Test bcast_1 with 1 MPI ranks PASSED!
Running bcast_1 with 2 MPI ranks...
 Rank=           0  received integer=           1
 Rank=           1  received integer=           1
Test bcast_1 with 2 MPI ranks PASSED!
Running bcast_1 with 4 MPI ranks...
 Rank=           0  received integer=           1
 Rank=           2  received integer=           1
 Rank=           1  received integer=           1
 Rank=           3  received integer=           1
Test bcast_1 with 4 MPI ranks PASSED!

... Running standalone tests took 4 seconds ...

```

This is because if we are working on making new MREs or Adding new tests then we do not have to run all the tests everytime