### PR TITLE
run MPI without wrappers for standalone tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,27 @@ env:
   MACOSX_DEPLOYMENT_TARGET: 14.0
 
 jobs:
+  Run_standalone_tests_without_custom_MPI_wrappers:
+    name: "Run standalone tests without custom MPI Wrappers"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-20.04"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@v2.0.2
+        with:
+          micromamba-version: '2.0.4-0'
+          environment-file: ci/environment_gfortran_openmpi.yml
+
+      - name: Run standalone tests with OpenMPI and without MPI wrappers
+        shell: bash -e -x -l {0}
+        run: |
+          cd tests
+          ./run_tests.sh --without-wrappers
+
   Run_standalone_tests_with_GFortran_with_OpenMPI:
     name: "Run standalone tests with GFortran with Open MPI"
     runs-on: ${{ matrix.os }}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -7,6 +7,21 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+USE_WRAPPERS=1
+# Process command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --without-wrappers)
+            USE_WRAPPERS=0
+            shift
+            ;;
+        *)
+            # Remaining arguments are test files
+            break
+            ;;
+    esac
+done
+
 MPIEXEC=${CONDA_PREFIX}/bin/mpiexec
 
 # detect MPI implementation
@@ -22,11 +37,24 @@ else
   exit 1
 fi
 
-if [[ "$(uname)" == "Linux" ]]; then
-  CC=gcc
+
+if [ $USE_WRAPPERS -eq 0 ]; then
+  FC=mpif90
 else
-  CC=clang
+  if [[ "$(uname)" == "Linux" ]]; then
+    CC=gcc
+  else
+    CC=clang
+  fi
 fi
+
+echo -e "${RED}Removing all untracked files${NC}"
+git clean -dfx
+echo -e "#################################"
+echo -e "${YELLOW}Using FC=${FC} compiler${NC}"
+echo -e "${YELLOW}Using CC=${CC} compiler${NC}"
+echo -e "################################"
+echo -e
 
 # If user specified a particular test (e.g. ./run_tests.sh bcast.f90),
 # then only build & run that file. Otherwise, build & run all *.f90 files.
@@ -40,10 +68,11 @@ else
   echo -e "${YELLOW}No specific test file given. Will compile/run all .f90 tests...${NC}"
 fi
 
-# Compile the C and Fortran sources for the MPI wrappers
-$CC -I"$CONDA_PREFIX/include" -c ../src/mpi_wrapper.c
-$FC -c ../src/mpi_c_bindings.f90
-$FC -c ../src/mpi.f90
+if [ $USE_WRAPPERS -eq 1 ]; then
+  $CC -I"$CONDA_PREFIX/include" -c ../src/mpi_wrapper.c
+  $FC -c ../src/mpi_c_bindings.f90
+  $FC -c ../src/mpi.f90
+fi
 
 start_time=$(date +%s)
 
@@ -57,8 +86,13 @@ for file in "${TEST_FILES[@]}"; do
   filename=$(basename "$file" .f90)
   echo -e "${YELLOW}Compiling $filename...${NC}"
   $FC -c "$file"
-  $FC mpi_wrapper.o mpi_c_bindings.o mpi.o "$filename.o" \
-     -o "$filename" -L"$CONDA_PREFIX/lib" -lmpi -Wl,-rpath,"$CONDA_PREFIX/lib"
+
+  if [ $USE_WRAPPERS -eq 1 ]; then
+    $FC mpi_wrapper.o mpi_c_bindings.o mpi.o "$filename.o" \
+      -o "$filename" -L"$CONDA_PREFIX/lib" -lmpi -Wl,-rpath,"$CONDA_PREFIX/lib"
+  else
+    $FC "$filename.o" -o "$filename"
+  fi
 
   # Test with 1, 2, and 4 ranks
   for np in 1 2 4; do


### PR DESCRIPTION
## Description

Added tests like: https://github.com/gxyd/c_mpi/pull/77 work with MPI without wrappers but don't work with our wrappers.

The CI check ensures that the added test program actually works as expected with and without our MPI wrappers in pretty much the same way.