### PR TITLE
run standalone tests without custom MPI wrappers with MPICH as well

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,8 +12,8 @@ env:
   MACOSX_DEPLOYMENT_TARGET: 14.0
 
 jobs:
-  Run_standalone_tests_without_custom_MPI_wrappers:
-    name: "Run standalone tests without custom MPI Wrappers"
+  Run_standalone_tests_without_custom_MPI_wrappers_with_OpenMPI:
+    name: "Run standalone tests with Open MPI without custom MPI Wrappers"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -28,6 +28,27 @@ jobs:
           environment-file: ci/environment_gfortran_openmpi.yml
 
       - name: Run standalone tests with OpenMPI and without MPI wrappers
+        shell: bash -e -x -l {0}
+        run: |
+          cd tests
+          ./run_tests.sh --without-wrappers
+
+  Run_standalone_tests_without_custom_MPI_wrappers_with_MPICH:
+    name: "Run standalone tests with MPICH without custom MPI Wrappers"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-20.04"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@v2.0.2
+        with:
+          micromamba-version: '2.0.4-0'
+          environment-file: ci/environment_gfortran_mpich.yml
+
+      - name: Run standalone tests with MPICH and without MPI wrappers
         shell: bash -e -x -l {0}
         run: |
           cd tests


### PR DESCRIPTION
## Description

Testing with just OpenMPI isn't enough, we'll need to make sure that the added test program work both with Open MPI and MPICH as well.

I've seen program (see e.g.; below), which don't work with one of them:

e.g.;
```f90
program cart_shift_1
    use mpi
    implicit none

    integer :: ierr, rank, size
    integer :: dims(2), comm_cart
    logical :: periods(2)
    integer :: rank_source, rank_dest
    integer :: coords(2)

    call MPI_INIT(ierr)
    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
    call MPI_COMM_SIZE(MPI_COMM_WORLD, size, ierr)

    dims(1) = 2          ! rows
    dims(2) = size/2     ! columns
    periods(1) = .false. ! non-periodic in x
    periods(2) = .false. ! non-periodic in y

    call MPI_CART_CREATE(MPI_COMM_WORLD, 2, dims, periods, .true., comm_cart, ierr)

    print *, "rank: ", rank
    if (comm_cart == MPI_COMM_NULL) then
        if (rank == 0) then
            print *, 'Error creating Cartesian communicator'
        endif
        call MPI_FINALIZE(ierr)
        stop
    end if

end program cart_shift_1

```
the above program doesn't work with Open MPI but works with MPICH on macOS.