### PR TITLE
simplify wrappers to define C MPI objects as global variables instead…

### DIFF
--- a/src/mpi.f90
+++ b/src/mpi.f90
@@ -722,7 +722,7 @@ module mpi
         integer(kind=MPI_HANDLE_KIND), dimension(count) :: c_requests
         type(c_ptr) :: MPI_STATUSES_IGNORE_from_c
 
-        MPI_STATUSES_IGNORE_from_c = c_mpi_statuses_ignore()
+        MPI_STATUSES_IGNORE_from_c = c_mpi_statuses_ignore
 
         ! Convert Fortran requests to C requests.
         do i = 1, count

--- a/src/mpi_c_bindings.f90
+++ b/src/mpi_c_bindings.f90
@@ -1,4 +1,5 @@
 module mpi_c_bindings
+    use iso_c_binding, only: c_ptr
     implicit none
 
 #ifdef OPEN_MPI
@@ -7,8 +8,10 @@ module mpi_c_bindings
 #define MPI_HANDLE_KIND 4
 #endif
 
+    type(c_ptr), bind(C, name="c_MPI_STATUSES_IGNORE") :: c_mpi_statuses_ignore
+
     interface
-    
+
         function c_mpi_comm_f2c(comm_f) bind(C, name="MPI_Comm_f2c")
             use iso_c_binding, only: c_int, c_ptr
             integer(c_int), value :: comm_f
@@ -62,11 +65,6 @@ module mpi_c_bindings
             integer(c_int), value :: info_f
             integer(kind=MPI_HANDLE_KIND) :: c_mpi_info_f2c
         end function c_mpi_info_f2c
-
-        function c_mpi_statuses_ignore() bind(C, name="get_c_MPI_STATUSES_IGNORE")
-            use iso_c_binding, only: c_ptr
-            type(c_ptr) :: c_mpi_statuses_ignore
-        end function c_mpi_statuses_ignore
 
         function c_mpi_in_place_f2c(in_place_f) bind(C,name="get_c_mpi_inplace_from_fortran")
             use iso_c_binding, only: c_double, c_ptr

--- a/src/mpi_wrapper.c
+++ b/src/mpi_wrapper.c
@@ -57,6 +57,4 @@ void* get_c_mpi_inplace_from_fortran(double sendbuf) {
     return MPI_IN_PLACE;
 }
 
-MPI_Status* get_c_MPI_STATUSES_IGNORE(){
-    return MPI_STATUSES_IGNORE;
-}
+MPI_Status* c_MPI_STATUSES_IGNORE = MPI_STATUSES_IGNORE;


### PR DESCRIPTION
… of functions