### PR TITLE
refactor to use MPI_HANDLE_KIND only in mpi_c_bindings.f90

### DIFF
--- a/src/mpi.f90
+++ b/src/mpi.f90
@@ -1,11 +1,6 @@
 module mpi
+    use mpi_c_bindings, only: MPI_HANDLE_KIND
     implicit none
-
-#ifdef OPEN_MPI
-#define MPI_HANDLE_KIND 8
-#else
-#define MPI_HANDLE_KIND 4
-#endif
 
     integer, parameter :: MPI_THREAD_FUNNELED = 1
 

--- a/src/mpi_c_bindings.f90
+++ b/src/mpi_c_bindings.f90
@@ -8,6 +8,7 @@ module mpi_c_bindings
 #define MPI_HANDLE_KIND 4
 #endif
 
+    integer, parameter :: mpi_handle_kind = MPI_HANDLE_KIND
     type(c_ptr), bind(C, name="c_MPI_STATUSES_IGNORE") :: c_mpi_statuses_ignore
     type(c_ptr), bind(C, name="c_MPI_IN_PLACE") :: c_mpi_in_place
     integer(kind=MPI_HANDLE_KIND), bind(C, name="c_MPI_INFO_NULL") :: c_mpi_info_null


### PR DESCRIPTION
## Description

define `MPI_HANDLE_KIND` preprocessor directive only in one file.

Maybe in the future once there are more preprocessor directives, we can move it to a dedicated config.h file?