### PR TITLE
fix: use MPI_STATUS_SIZE=6 for Open MPI (avoids 4-byte stack overflow)

### DIFF
--- a/src/mpi.f90
+++ b/src/mpi.f90
@@ -26,7 +26,16 @@ module mpi
     integer, parameter :: MPI_MAX = -2301
     integer, parameter :: MPI_LOR = -2302
     integer, parameter :: MPI_INFO_NULL = -2000
+    ! MPI_STATUS_SIZE must match sizeof(MPI_Status)/sizeof(int) of the underlying
+    ! C library. Open MPI 5.x uses a 6-int (24-byte) MPI_Status, whereas MPICH
+    ! and older Open MPI releases used a 5-int (20-byte) layout. If the two
+    ! disagree the native MPI_Recv/etc. will write past the Fortran status
+    ! buffer and corrupt the surrounding stack.
+#ifdef OPEN_MPI
+    integer, parameter :: MPI_STATUS_SIZE = 6
+#else
     integer, parameter :: MPI_STATUS_SIZE = 5
+#endif
     integer :: MPI_STATUS_IGNORE = 0
     ! NOTE: I've no idea for how to implement this, refer
     ! see section 2.5.4 page 21 of mpi40-report.pdf


### PR DESCRIPTION
## Summary

- Open MPI 5.x uses a 6-int (24-byte) `MPI_Status`, but the Fortran binding hardcoded `MPI_STATUS_SIZE = 5`. This causes the native `MPI_Recv` (and any other status-writing call) to write 4 bytes past the end of the Fortran `tmp_status` buffer allocated inside our wrappers, corrupting the caller's stack.
- Depending on the caller's exact stack layout, this manifests as a hard segfault deep inside a subsequent runtime call (e.g. `_lcompilers_string_format_fortran`) at a suspicious address such as `0x7fff00000000` — the upper half of a stack pointer left over after the 4-byte overflow.
- Gate `MPI_STATUS_SIZE` on the existing `-DOPEN_MPI` preprocessor symbol (already used elsewhere in `mpi_c_bindings.f90`) so it matches the underlying C header:
  - Open MPI  → 6
  - MPICH     → 5 (unchanged)

## Rationale

Verified against Open MPI 5.0.10 that `sizeof(MPI_Status) == 24` and the Fortran binding shipped by `mpi.mod` exposes `MPI_STATUS_SIZE = 6`. Our own binding must agree, otherwise we hand C a smaller buffer than it expects.

## Verification

- Repro (before): `tests/recv_1.f90` crashes with `Segmentation fault: address not mapped to object at address 0x7fff00000000` inside `print_into_string` of the LFortran runtime.
- After this fix: the full `tests/run_tests.sh` suite passes (57/57 test-rank combinations, including `recv_1`) at the currently pinned upstream commit `31033d3` using LFortran built with LLVM 15 on Linux/x86_64 with Open MPI 5.0.10.

## Test plan

- [x] `FC="lfortran --cpp" ./tests/run_tests.sh` passes end-to-end with Open MPI 5.
- [ ] Re-check under MPICH (unchanged path) — no source changes on that leg beyond additional comments.


Made with [Cursor](https://cursor.com)